### PR TITLE
gorylenko.gradle-git-properties plugin updated to 2.3.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
     id 'java' //apply false
     id 'application'
     id 'distribution'
-    id "com.gorylenko.gradle-git-properties" version "2.2.2"
+    id "com.gorylenko.gradle-git-properties" version "2.3.2"
     id "com.github.langmo.gradlensis" version "0.1.0"
 
     id "eclipse"


### PR DESCRIPTION
the gorylenko.gradle-git-properties plugin (line11 of build.gradle file)needed to be updated from 2.2.2 version to 2.3.2. This is the only change to the project. 